### PR TITLE
Fix use-reset-token command hint

### DIFF
--- a/tools/cli/src/cli/person.rs
+++ b/tools/cli/src/cli/person.rs
@@ -588,7 +588,7 @@ impl AccountCredential {
                         println!();
                         println!("This link: {}", url.as_str());
                         println!(
-                            "Or run this command: kanidm person credential use_reset_token {}",
+                            "Or run this command: kanidm person credential use-reset-token {}",
                             cuintent_token.token
                         );
                         println!();


### PR DESCRIPTION
running

`kanidm person credential create-reset-token` 

prints out information how to do credential reset.

This fixes the provided cli command.
